### PR TITLE
Ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+.ruby-version
 
 /spec/fake_app/log/


### PR DESCRIPTION
This will make it a little bit easier for rbenv users to contribute to this repository.