### PR TITLE
Explicitly branch default formatter based on duck type

### DIFF
--- a/lib/table_help/config.rb
+++ b/lib/table_help/config.rb
@@ -11,7 +11,8 @@ module TableHelp
 
     DEFAULT_FORMATTER = {
       attribute_name: ->(name, collection_or_resource) do
-        if collection_or_resource.respond_to?(:model)
+        case collection_or_resource
+        when ActiveRecord::Relation
           collection_or_resource.model.human_attribute_name(name)
         else
           collection_or_resource.class.human_attribute_name(name)


### PR DESCRIPTION
Generating an attributes_table_for objects decorated with the Draper gem triggers
```
ActionView::Template::Error (undefined method human_attribute_name for #<MyActiveRecordModel:0x001a2b3c>)
```

The current default ends up calling Draper::Decorator#model which returns the **instance** of the model instead of its **class**.