### PR TITLE
Support for Enumerable

### DIFF
--- a/lib/table_help/config.rb
+++ b/lib/table_help/config.rb
@@ -14,6 +14,8 @@ module TableHelp
         case collection_or_resource
         when ActiveRecord::Relation
           collection_or_resource.model.human_attribute_name(name)
+        when Enumerable
+          collection_or_resource.first.class.human_attribute_name(name)
         else
           collection_or_resource.class.human_attribute_name(name)
         end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe TableHelp::Helper do
         is_expected.to have_css "td.col-title", text: "My Awesome Title"
       end
     end
+
+    context "when passed an ActiveRecord::Relation" do
+      let(:articles) { Article.all.to_a }
+
+      it "builds an HTML table" do
+        is_expected.to have_css "td.col-title", text: "My Awesome Title"
+      end
+    end
   end
 
   describe "#attributes_table_for" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe TableHelp::Helper do
+  include TableHelp::Helper
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
+  include Capybara::RSpecMatchers
+
+  describe "#table_for" do
+    before do
+      Article.create(title: "My Awesome Title", body: "Lorem ipsum dolor sit amet")
+    end
+
+    subject do
+      table_for articles do |t|
+        t.column :title
+      end
+    end
+
+    context "when passed an ActiveRecord::Relation" do
+      let(:articles) { Article.all }
+
+      it "builds an HTML table" do
+        is_expected.to have_css "td.col-title", text: "My Awesome Title"
+      end
+    end
+  end
+
+  describe "#attributes_table_for" do
+    let(:article) { Article.new(title: "My Awesome Title") }
+
+    subject do
+      attributes_table_for article do |t|
+        t.row :title
+      end
+    end
+
+    it "builds an HTML table" do
+      is_expected.to have_css "td.col-title", text: "My Awesome Title"
+    end
+  end
+end


### PR DESCRIPTION
Passing an Array into `table_for` triggers a `NoMethodError: undefined method 'human_attribute_name' for Array:Class`.

I added support for `Enumerable` to the default formatter, as well as tests at the helper level.