### PR TITLE
Support for empty Enumerables

### DIFF
--- a/lib/table_help/config.rb
+++ b/lib/table_help/config.rb
@@ -15,7 +15,7 @@ module TableHelp
         when ActiveRecord::Relation
           collection_or_resource.model.human_attribute_name(name)
         when Enumerable
-          collection_or_resource.first.class.human_attribute_name(name)
+          collection_or_resource.first.class.human_attribute_name(name) unless collection_or_resource.empty?
         else
           collection_or_resource.class.human_attribute_name(name)
         end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -26,11 +26,19 @@ RSpec.describe TableHelp::Helper do
       end
     end
 
-    context "when passed an ActiveRecord::Relation" do
+    context "when passed an Enumerable" do
       let(:articles) { Article.all.to_a }
 
       it "builds an HTML table" do
         is_expected.to have_css "td.col-title", text: "My Awesome Title"
+      end
+    end
+
+    context "when passed an empty Enumerable" do
+      let(:articles) { [] }
+
+      it "does not build an HTML table" do
+        is_expected.to be_nil
       end
     end
   end


### PR DESCRIPTION
I forgot to account for empty Enumerables in #11. Sorry 🙇 

Without the changes in this pull request, `table_for([])` triggers an `undefined method 'human_attribute_name' for NilClass:Class` error.